### PR TITLE
JJTraveler is BSD licensed, not GPL.

### DIFF
--- a/dev/dependencies/index.md
+++ b/dev/dependencies/index.md
@@ -32,7 +32,7 @@ GMF Tooling                    | <http://eclipse.org/gmf-tooling/>              
 Guava                          | <https://code.google.com/p/guava-libraries/>                                                                        | [Apache 2.0](http://www.tldrlegal.com/l/apache2)
 Functional Java                | <http://functionaljava.org/>                                                                                        | [BSD 3-way](http://www.tldrlegal.com/l/bsd3)
 JLine                          | <http://jline.sourceforge.net/>                                                                                     | [BSD 3-way](http://www.tldrlegal.com/l/bsd3)
-JJTraveler                     | <https://github.com/ansell/jjtraveler>                                                                              | [__GPL 2.0 !!__](http://www.tldrlegal.com/l/gpl2)
+JJTraveler                     | <https://github.com/ansell/jjtraveler>                                                                              | [BSD 3-way](http://www.tldrlegal.com/l/bsd3)
 ATerm shared-objects           | <https://github.com/ansell/aterms/tree/master/shared-objects>                                                       | [Permissive](https://github.com/ansell/aterms/blob/master/shared-objects/COPYING)
 JCommander                     | <http://jcommander.org/>                                                                                            | [Apache 2.0](http://www.tldrlegal.com/l/apache2)
 Apache Commons I/O             | <http://commons.apache.org/>                                                                                        | [Apache 2.0](http://www.tldrlegal.com/l/apache2)


### PR DESCRIPTION
I created a pull request to have the outdated license information removed from JJTraveler.
Pull request: https://github.com/ansell/jjtraveler/compare/ansell:master...oskarvanrest:patch-1?expand=1
Commit: https://github.com/ansell/jjtraveler/commit/9565a0f5d27ba726832571c3ade512922bfa6097