### PR TITLE
Put a link to the documentation repo

### DIFF
--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -47,6 +47,8 @@ Please open an issue _first_, so we can discuss the change.
 #### :fontawesome-solid-book-medical:&nbsp; I want to contribute to the documentation or test suite
 Thank you! Please open a GitHub pull request with the patch.
 
+Documentation repo: https://github.com/metaborg/metaborg.github.io/
+
 ---
 
 Thank you for your contributions!


### PR DESCRIPTION
To save contributors from searching for the right repo when they want to propose fixes to the docs.