### PR TITLE
Update the list of meta-languages

### DIFF
--- a/docs/languages/index.md
+++ b/docs/languages/index.md
@@ -2,37 +2,82 @@
 title: "Languages"
 ---
 # Spoofax Languages
-This is a curated list of Spoofax languages and links to their documentation.
+This is a curated list of Spoofax languages, with links to their reference documentation (if available) and source code.
 
 ## Spoofax meta-languages
-These are the Spoofax meta-languages:
+Some of the Spoofax meta-languages listed below have been superseded, and their use is now deprecated.
 
 ### Syntax
 The recommended language for specifying syntax is SDF3.
 
-- [SDF3](sdf3/index.md)
-- [SDF2](sdf2/index.md)
+- SDF3:
+  [:material-file-cog: Reference](../references/syntax/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/sdf/tree/master/org.metaborg.meta.lang.template){ .sm-button }
+- SDF2:
+  [:material-source-branch: Source code](https://github.com/metaborg/sdf/tree/master/org.metaborg.meta.lang.sdf){ .sm-button }
 
 ### Static Semantics
 The recommended language for specifying static semantics is Statix.
 
-- Statix
-- NaBL 2
-- NaBL + TS
+- Statix:
+  [:material-file-cog: Reference](../references/statix/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/nabl/tree/master/statix.lang){ .sm-button }
+- NaBL 2:
+  [:material-source-branch: Source code](https://github.com/metaborg/nabl/tree/master/nabl2.lang){ .sm-button }
+- NaBL:
+  [:material-source-branch: Source code](https://github.com/metaborg/nabl/tree/master/org.metaborg.meta.lang.nabl){ .sm-button }
+  \+ TS:
+  [:material-source-branch: Source code](https://github.com/metaborg/ts/tree/master/org.metaborg.meta.lang.ts){ .sm-button }
 
 ### Term Transformations
 The recommended language for specifying term transformations is Stratego 2.
 
-- Stratego 2
-- Stratego
+- Stratego 2:
+  [:material-file-cog: Reference](../references/stratego/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/stratego/tree/master/stratego.lang){ .sm-button }
+- Stratego:
+  [:material-source-branch: Source code](https://github.com/metaborg/stratego/tree/master/org.metaborg.meta.lang.stratego){ .sm-button }
 
-### Misc
+### Testing
+The recommended language for specifying tests of Spoofax languages is SPT.
 
-- ESV
-- Cfg
+- SPT:
+  [:material-file-cog: Reference](../references/testing/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/spt/tree/master/org.metaborg.meta.lang.spt){ .sm-button }
+
+### Dynammic semantics
+The languages for specifying dynamic semantics are DynSem and Dynamix.
+
+- Dynamix:
+  [:material-source-branch: Source code](https://github.com/metaborg/metaborg-dynamix/tree/master/lang.dynamix){ .sm-button }
+- DynSem:
+  [:material-source-branch: Source code](https://github.com/metaborg/dynsem/tree/master/dynsem){ .sm-button }
+
+### Editor services
+The language for specifying editor services is ESV.
+
+- ESV:
+  [:material-file-cog: Reference](../references/editor-services/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/esv/tree/master/org.metaborg.meta.lang.esv){ .sm-button }
+
+
+### Data flow analysis
+The language for specifying data flow analysis is FlowSpec.
+
+- FlowSpec:
+  [:material-file-cog: Reference](../references/flowspec/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/flowspec/tree/master/flowspec.lang){ .sm-button }
+
+### Pipelines
+Pipelines for interactive Environments (PIE) is the build system for Spoofax 3.
+
+- PIE:
+  [:material-file-cog: Reference](../references/pipelines/index.md){ .sm-button }
+  [:material-source-branch: Source code](https://github.com/metaborg/pie/tree/develop/lang/lang){ .sm-button }
 
 
 ## Spoofax Language Projects
-These are some of the Spoofax language projects:
+This is a Spoofax language project:
 
-- Java Front
+- Java Front:
+  [:material-source-branch: Source code](ttps://github.com/metaborg/java-front/tree/master/lang.java){ .sm-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,10 +19,10 @@ nav:
     - tutorials/index.md
   - Languages:
     - languages/index.md
-    - SDF3:
-      - languages/sdf3/index.md
-    - SDF2:
-      - languages/sdf2/index.md
+    # - SDF3:
+    #   - languages/sdf3/index.md
+    # - SDF2:
+    #   - languages/sdf2/index.md
   - How-Tos:
     - howtos/index.md
     - Installation:


### PR DESCRIPTION
- Complete the top-level list of meta-languages.
- Add links to reference and source code projects.
- Comment-out the nav links for SDF2 and SDF3 pages.

Feel free to edit the PR branch directly, rather than suggesting changes for me to make.

BTW, I'm aware that there's a different list of meta-languages at https://spoofax.dev/howtos/development/.

Note: The small buttons in the updated Languages page look a bit untidy. The SDF2 and SDF3 pages used nicely-aligned medium buttons, but I don't think they are designed for inline use. A table might look better.